### PR TITLE
Add updateCount and clear data after send

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Statsd::increment($key);
 Statsd::decrement($key);
 ```
 
+```php
+Statsd::updateCount($key, $delta);
+```
+
 The data is automatically sent to Statsd at the end of Laravels life-cycle, but you can force data to be sent with:
 
 ```php

--- a/src/rcrowe/Statsd/Statsd.php
+++ b/src/rcrowe/Statsd/Statsd.php
@@ -172,6 +172,7 @@ class Statsd implements StatsdDataFactoryInterface
         // Only call send if enabled and we have data
         if ($this->enabled AND count($this->data) > 0) {
             $this->client->send($this->data);
+            $this->data = [];
         }
     }
 }

--- a/src/rcrowe/Statsd/Statsd.php
+++ b/src/rcrowe/Statsd/Statsd.php
@@ -146,6 +146,14 @@ class Statsd implements StatsdDataFactoryInterface
     /**
      * @inherit
      **/
+    function updateCount($key, $delta)
+    {
+        $this->data[] = $this->factory->updateCount($key, $delta);
+    }
+
+    /**
+     * @inherit
+     **/
     function produceStatsdData($key, $value = 1, $metric = StatsdDataInterface::STATSD_METRIC_COUNT)
     {
         return $this->factory->produceStatsdData($key, $value, $metric);

--- a/src/rcrowe/Statsd/Statsd.php
+++ b/src/rcrowe/Statsd/Statsd.php
@@ -172,7 +172,7 @@ class Statsd implements StatsdDataFactoryInterface
         // Only call send if enabled and we have data
         if ($this->enabled AND count($this->data) > 0) {
             $this->client->send($this->data);
-            $this->data = [];
+            $this->data = array();
         }
     }
 }

--- a/tests/StatsdTest.php
+++ b/tests/StatsdTest.php
@@ -197,6 +197,9 @@ class StatsdTest extends PHPUnit_Framework_TestCase
         $statsd->timing('key', time());
 
         $statsd->send();
+
+        $data = $statsd->getData();
+        $this->assertTrue(count($data) === 0);
     }
 
     public function testDisable()

--- a/tests/StatsdTest.php
+++ b/tests/StatsdTest.php
@@ -113,6 +113,26 @@ class StatsdTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($data[1], 'two');
     }
 
+    public function testUpdateCount()
+    {
+        $factory = m::mock('Liuggio\StatsdClient\Factory\StatsdDataFactory');
+        $factory->shouldReceive('updateCount')->twice()->andReturn('one', 'two');
+
+        $statsd = new Statsd;
+        $statsd->setFactory($factory);
+
+        $this->assertTrue(count($statsd->getData()) === 0);
+
+        $statsd->updateCount('key', 2);
+        $statsd->updateCount('key', 4);
+
+        $data = $statsd->getData();
+
+        $this->assertTrue(count($data) === 2);
+        $this->assertEquals($data[0], 'one');
+        $this->assertEquals($data[1], 'two');
+    }
+
     public function testAllCalled()
     {
         $factory = m::mock('Liuggio\StatsdClient\Factory\StatsdDataFactory');
@@ -121,6 +141,7 @@ class StatsdTest extends PHPUnit_Framework_TestCase
         $factory->shouldReceive('set')->once()->andReturn('set');
         $factory->shouldReceive('increment')->once()->andReturn('increment');
         $factory->shouldReceive('decrement')->once()->andReturn('decrement');
+        $factory->shouldReceive('updateCount')->once()->andReturn('updateCount');
 
         $statsd = new Statsd;
         $statsd->setFactory($factory);
@@ -130,15 +151,17 @@ class StatsdTest extends PHPUnit_Framework_TestCase
         $statsd->set('key', 'value');
         $statsd->increment('key');
         $statsd->decrement('key');
+        $statsd->updateCount('key', 2);
 
         $data = $statsd->getData();
 
-        $this->assertTrue(count($data) === 5);
+        $this->assertTrue(count($data) === 6);
         $this->assertEquals($data[0], 'timing');
         $this->assertEquals($data[1], 'gauge');
         $this->assertEquals($data[2], 'set');
         $this->assertEquals($data[3], 'increment');
         $this->assertEquals($data[4], 'decrement');
+        $this->assertEquals($data[5], 'updateCount');
     }
 
     public function testDataTypeStored()


### PR DESCRIPTION
Nice package and upon using the package I would like to make 2 updates:
1. Implement StatsdDataFactoryInterface::updateCount liuggio/statsd-php-client from v1.0.12 (latest stable).
2. Clear data after current data being sent (flush and clear buffer), so clients can call send on-demand in additional to app shutdown, useful for long running background process.
